### PR TITLE
Add proton and newer pressure vessel process names

### DIFF
--- a/discord-steam-proton-rpc/Program.cs
+++ b/discord-steam-proton-rpc/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -173,8 +173,10 @@ public class Program
             steamProcesses = steamProcesses.Concat(Process.GetProcessesByName("reaper"));
         if (settings.hideProtonWineProcessesFromDiscordUsingSymbolicLinks)
             steamProcesses = steamProcesses
+                .Concat(Process.GetProcessesByName("proton"))
                 .Concat(Process.GetProcessesByName("wineserver"))
-                .Concat(Process.GetProcessesByName("pressure-vessel-wrap"));
+                .Concat(Process.GetProcessesByName("pressure-vessel-wrap"))
+                .Concat(Process.GetProcessesByName("pv-bwrap"));
 
         return steamProcesses;
     }


### PR DESCRIPTION
These processes appear when launching games with Proton 8.0+ adding this hides them fully as intended.